### PR TITLE
fix(naming): use 'execute' instead of 'find' on driving-adapter/input…

### DIFF
--- a/pkg/domain/ports/input.go
+++ b/pkg/domain/ports/input.go
@@ -3,5 +3,5 @@ package ports
 import "github.com/psavelis/go-tuner-api/pkg/domain/entity"
 
 type FindNoteByFrequency interface {
-	Find(frequencyInHz float64) (entity.StandardNote, error)
+	Execute(frequencyInHz float64) (entity.StandardNote, error)
 }

--- a/pkg/domain/usecase/find_note.go
+++ b/pkg/domain/usecase/find_note.go
@@ -28,7 +28,7 @@ func getKey(frequency float64) int {
 	return int(12*math.Log2(frequency/temperingHz) + 49)
 }
 
-func (s *service) Find(frequencyInHz float64) (entity.StandardNote, error) {
+func (s *service) Execute(frequencyInHz float64) (entity.StandardNote, error) {
 	key := getKey(frequencyInHz)
 
 	note, err := s.repository.Find(key)

--- a/pkg/infra/handler/http/controller.go
+++ b/pkg/infra/handler/http/controller.go
@@ -25,7 +25,7 @@ func (handler *HTTPHandler) Handle(c *gin.Context) {
 		return
 	}
 
-	standardNote, err := handler.inPort.Find(frequency)
+	standardNote, err := handler.inPort.Execute(frequency)
 
 	if err != nil {
 		c.JSON(404, gin.H{"404": err.Error()})


### PR DESCRIPTION
…-port method name

* Ports and Adapters convention standardization

* Closes #1 